### PR TITLE
Removed members collection and added entertainement section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,9 @@ collections:
   issues:
     output: true
     permalink: /:year/:month/
-  members:
+  entertainment:
+    output: true
+    permalink: /fun/:title/
 
 compress_html:
   blanklines: false

--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ collections:
     permalink: /:year/:month/
   entertainment:
     output: true
-    permalink: /fun/:title/
+    permalink: /fun/:name/
 
 compress_html:
   blanklines: false


### PR DESCRIPTION
Note that entertainment items should be stored in the `_entertainment` subdirectory

Entertainment items will be findable at `floundernews.tk/fun/<title>`