### PR TITLE
Disable CSS smooth scrolling to fix anchor links on Chrome

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -9,7 +9,6 @@
 html,
 body {
   min-height: 100vh;
-  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
Fixes #93 